### PR TITLE
Babelify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "url": "https://github.com/stolksdorf/smart-objects/issues"
   },
   "dependencies": {
-    "underscore": "^1.6.0"
+    "lodash": "^3.10.1"
   }
 }

--- a/smart-objects.js
+++ b/smart-objects.js
@@ -1,4 +1,4 @@
-var _ = (typeof require == 'function' && require('underscore')) || _;
+var _ = (typeof require == 'function' && require('lodash')) || _;
 
 (function(){
 

--- a/smart-objects.js
+++ b/smart-objects.js
@@ -35,7 +35,7 @@ var _ = (typeof require == 'function' && require('lodash')) || _;
 	};
 
 
-	buildProps = function(rootObj, obj, _props, recipes, startingProps, _v){
+	var buildProps = function(rootObj, obj, _props, recipes, startingProps, _v){
 		startingProps = startingProps || {};
 		_.each(recipes, function(propVal, propName){
 			//Default to 'any' type
@@ -104,7 +104,7 @@ var _ = (typeof require == 'function' && require('lodash')) || _;
 
 
 
-	smartObject = function(blueprint){
+	var smartObject = function(blueprint){
 		blueprint.statics = blueprint.statics || {};
 
 		var _v = {};


### PR DESCRIPTION
Switched dependency from `underscore` to `lodash` and fixed small issues causing Babel compilation to fail.
